### PR TITLE
Allow logging to be disabled for individual classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "1.0" // your current series x.y
+ThisBuild / tlBaseVersion := "2.0" // your current series x.y
 
 ThisBuild / organization := "com.permutive"
 ThisBuild / organizationName := "Permutive"

--- a/odin-dynamic/src/test/scala/com/permutive/logging/dynamic/odin/DynamicOdinLoggerSpec.scala
+++ b/odin-dynamic/src/test/scala/com/permutive/logging/dynamic/odin/DynamicOdinLoggerSpec.scala
@@ -18,7 +18,10 @@ package com.permutive.logging.dynamic.odin
 
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Resource}
-import com.permutive.logging.dynamic.odin.DynamicOdinConsoleLogger.RuntimeConfig
+import com.permutive.logging.dynamic.odin.DynamicOdinConsoleLogger.{
+  LevelConfig,
+  RuntimeConfig
+}
 import com.permutive.logging.odin.testing.OdinRefLogger
 import io.odin.{Level, LoggerMessage}
 import io.odin.formatter.Formatter
@@ -81,7 +84,7 @@ class DynamicOdinLoggerSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
             logger.update(
               RuntimeConfig(
                 Level.Info,
-                Map(positionWhichChangesLevel.enclosureName -> Level.Warn)
+                Map(positionWhichChangesLevel.enclosureName -> LevelConfig.Warn)
               )
             ) >>
             logger.info(infoMsg2Pos1)(implicitly, positionWhichChangesLevel) >>

--- a/odin-dynamic/src/test/scala/com/permutive/logging/dynamic/odin/DynamicOdinLoggerSpec.scala
+++ b/odin-dynamic/src/test/scala/com/permutive/logging/dynamic/odin/DynamicOdinLoggerSpec.scala
@@ -83,7 +83,7 @@ class DynamicOdinLoggerSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
     }
   }
 
-  test("update default-level config") {
+  test("raises default-level config") {
     PropF.forAllF { (messageBeforeChange: String, messageAfterChange: String) =>
       val messages = runTest() { logger =>
         logger.info(messageBeforeChange) >>
@@ -94,6 +94,20 @@ class DynamicOdinLoggerSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
       messages
         .map(_.map(_.message.value).toList)
         .assertEquals(List(messageBeforeChange))
+    }
+  }
+
+  test("lowers default-level config") {
+    PropF.forAllF { (messageBeforeChange: String, messageAfterChange: String) =>
+      val messages = runTest() { logger =>
+        logger.info(messageBeforeChange) >>
+          IO.sleep(10.millis) >>
+          logger.update(RuntimeConfig(defaultLevel = Level.Debug)) >>
+          logger.debug(messageAfterChange)
+      }
+      messages
+        .map(_.map(_.message.value).toList)
+        .assertEquals(List(messageBeforeChange, messageAfterChange))
     }
   }
 

--- a/odin-dynamic/src/test/scala/com/permutive/logging/dynamic/odin/DynamicOdinLoggerSpec.scala
+++ b/odin-dynamic/src/test/scala/com/permutive/logging/dynamic/odin/DynamicOdinLoggerSpec.scala
@@ -18,10 +18,13 @@ package com.permutive.logging.dynamic.odin
 
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Resource}
+import com.permutive.logging.dynamic.odin.DynamicOdinConsoleLogger.RuntimeConfig
 import com.permutive.logging.odin.testing.OdinRefLogger
 import io.odin.{Level, LoggerMessage}
 import io.odin.formatter.Formatter
+import io.odin.meta.Position
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.Arbitrary
 import org.scalacheck.effect.PropF
 
 import scala.collection.immutable.Queue
@@ -31,6 +34,13 @@ class DynamicOdinLoggerSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   implicit val runtime: IORuntime = IORuntime.global
 
+  implicit val arbPosition: Arbitrary[Position] =
+    Arbitrary(
+      Arbitrary
+        .arbitrary[(String, String, String, Int)]
+        .map((Position.apply _).tupled)
+    )
+
   test("record a message") {
     PropF.forAllF { (message: String) =>
       val messages = runTest(_.info(message))
@@ -39,34 +49,48 @@ class DynamicOdinLoggerSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
     }
   }
 
-  test("update global log level") {
-    PropF.forAllF { (message1: String, message2: String) =>
+  test("update min-level config") {
+    PropF.forAllF { (messageBeforeChange: String, messageAfterChange: String) =>
       val messages = runTest { logger =>
-        logger.info(message1) >> IO.sleep(10.millis) >> logger.update(
-          DynamicOdinConsoleLogger.RuntimeConfig(Level.Warn)
-        ) >> logger.info(
-          message2
-        )
+        logger.info(messageBeforeChange) >>
+          IO.sleep(10.millis) >>
+          logger.update(RuntimeConfig(minLevel = Level.Warn)) >>
+          logger.info(messageAfterChange)
       }
-      messages.map(_.map(_.message.value).toList).assertEquals(List(message1))
+      messages
+        .map(_.map(_.message.value).toList)
+        .assertEquals(List(messageBeforeChange))
     }
   }
 
   test("update enclosure log level") {
-    PropF.forAllF { (message1: String, message2: String, message3: String) =>
-      val messages = runTest { logger =>
-        logger.info(message1) >> IO.sleep(10.millis) >> logger.update(
-          DynamicOdinConsoleLogger.RuntimeConfig(
-            Level.Info,
-            Map("com.permutive" -> Level.Warn)
-          )
-        ) >> logger.info(
-          message2
-        ) >> logger.warn(message3)
-      }
-      messages
-        .map(_.map(_.message.value).toList)
-        .assertEquals(List(message1, message3))
+    PropF.forAllNoShrinkF {
+      (
+          infoMsg1Pos1: String,
+          infoMsg2Pos1: String,
+          warnMsg1Pos1: String,
+          infoMsg2Pos2: String,
+          position1: Position,
+          position2: Position
+      ) =>
+        val messages = runTest { logger =>
+          val positionWhichChangesLevel =
+            position1.copy(enclosureName = position1.enclosureName + "changes")
+          logger.info(infoMsg1Pos1)(implicitly, positionWhichChangesLevel) >>
+            IO.sleep(10.millis) >>
+            logger.update(
+              RuntimeConfig(
+                Level.Info,
+                Map(positionWhichChangesLevel.enclosureName -> Level.Warn)
+              )
+            ) >>
+            logger.info(infoMsg2Pos1)(implicitly, positionWhichChangesLevel) >>
+            logger.warn(warnMsg1Pos1)(implicitly, positionWhichChangesLevel) >>
+            logger.info(infoMsg2Pos2)(implicitly, position2)
+        }
+        messages
+          .map(_.map(_.message.value).toList)
+          .assertEquals(List(infoMsg1Pos1, warnMsg1Pos1, infoMsg2Pos2))
     }
   }
 
@@ -77,7 +101,7 @@ class DynamicOdinLoggerSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
     dynamic <- DynamicOdinConsoleLogger.create[IO](
       DynamicOdinConsoleLogger
         .Config(formatter = Formatter.default, asyncTimeWindow = 0.nanos),
-      DynamicOdinConsoleLogger.RuntimeConfig(Level.Info)
+      RuntimeConfig(Level.Info)
     )(config => testLogger.withMinimalLevel(config.minLevel))
     _ <- Resource.eval(useLogger(dynamic))
   } yield testLogger)


### PR DESCRIPTION
This adds a new `OFF` configuration which can be specified for a particular enclosure (ie. such as a class)in the `RuntimeConfig`. 

This allows the logging to be completely disabled for that enclosure; previously it was only possible to raise the level up to `ERROR`.  

